### PR TITLE
Feature/add support for nip 28 events

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -286,6 +286,12 @@ function eventBadge(event) {
         badge += ` Something about chess: ${escapeHTML(event.content)}`
         break
       }
+    case 42: {
+        const eTag = event.tags.find(tag => tag[0] === 'e')
+        const publicChatPubkey = eTag[1];
+        badge += ` Sent a new message to channel ${publicChatPubkey}`
+        break
+    }
     case 60: {
         badge += ` Something about ride sharing: ${escapeHTML(event.content)}`
         break

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -297,8 +297,8 @@ function eventBadge(event) {
     }
     case 42: {
         const eTag = event.tags.find(tag => tag[0] === 'e')
-        const publicChatPubkey = eTag[1];
-        badge += ` Sent a new message to channel ${publicChatPubkey}`
+        const channelPubkey = eTag[1];
+        badge += ` Sent a new message to channel ${channelPubkey}`
         break
     }
     case 43: {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -291,6 +291,10 @@ function eventBadge(event) {
         badge += ` Created a new channel called "${content.name}"`
         break
     }
+    case 41: {
+        badge += ` Updated channel metadata`
+        break
+    }
     case 42: {
         const eTag = event.tags.find(tag => tag[0] === 'e')
         const publicChatPubkey = eTag[1];

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -301,6 +301,13 @@ function eventBadge(event) {
         badge += ` Sent a new message to channel ${publicChatPubkey}`
         break
     }
+    case 43: {
+        const content = JSON.parse(event.content)
+        console.log(content)
+        const reason = content.reason ? content.reason : "Unknown reason"
+        badge += ` Hid a message (${reason})`
+        break
+    }
     case 60: {
         badge += ` Something about ride sharing: ${escapeHTML(event.content)}`
         break

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -308,6 +308,14 @@ function eventBadge(event) {
         badge += ` Hid a message (${reason})`
         break
     }
+    case 44: {
+        const pTag = event.tags.find(tag => tag[0] === 'p')
+        const mutedPubkey = pTag[1]
+        const content = JSON.parse(event.content)
+        const reason = content.reason ? content.reason : "Unknown reason"
+        badge += ` Muted user ${nameFromPubkey(mutedPubkey)} (${reason})}}`
+        break
+    }
     case 60: {
         badge += ` Something about ride sharing: ${escapeHTML(event.content)}`
         break

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -303,7 +303,6 @@ function eventBadge(event) {
     }
     case 43: {
         const content = JSON.parse(event.content)
-        console.log(content)
         const reason = content.reason ? content.reason : "Unknown reason"
         badge += ` Hid a message (${reason})`
         break

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -286,6 +286,11 @@ function eventBadge(event) {
         badge += ` Something about chess: ${escapeHTML(event.content)}`
         break
       }
+    case 40: {
+        const content = JSON.parse(event.content)
+        badge += ` Created a new channel called "${content.name}"`
+        break
+    }
     case 42: {
         const eTag = event.tags.find(tag => tag[0] === 'e')
         const publicChatPubkey = eTag[1];

--- a/relays.md
+++ b/relays.md
@@ -38,6 +38,11 @@ permalink: /relays/
     <option value="6">kind-6: Quoted Boost</option>
     <option value="7">kind-7: Reactions</option>
     <option value="30">kind-30: Chess</option>
+    <option value="40">kind-40: Channel created</option>
+    <option value="41">kind-41: Channel metadata update</option>
+    <option value="42">kind-42: Channel message</option>
+    <option value="43">kind-43: Hide message</option>
+    <option value="44">kind-44: Mute user</option>
     <option value="60">kind-60: Ride Sharing</option>
   </select>
   <br>


### PR DESCRIPTION
Since NIP-28 enabled nostr clients have become so popular lately, I figured it would be nice to have support for the NIP-28 kind range on nostr.info.

NIP-28 spec can be found here: https://github.com/nostr-protocol/nips/blob/master/28.md
